### PR TITLE
explicit brewfile path

### DIFF
--- a/setup/brew.sh
+++ b/setup/brew.sh
@@ -28,7 +28,7 @@ brew upgrade
 
 # Install fonts, tools, apps & vscode extensions
 title "Installing software..."
-brew bundle | indent
+brew bundle --file=./setup/Brewfile | indent
 
 # Extra apps
 echo ""


### PR DESCRIPTION
Since it's triggered by a ./setup/brew.sh the correct path to the brew file is not the current (as it is by default), but the a child of ./setup/